### PR TITLE
Change default topic to avoid collision with Publish Point tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ tool will publish the point in 3D space of the object on which the cursor rests
 
 The base class of the tool cursor has the following properties:
 
-- `Topic`: The topic on which to publish the 3D point in the Rviz environment when the left mouse button is clicked
+- `Pose Topic`: The topic on which to publish the 3D pose in the Rviz environment when the left mouse button is clicked
+- `Point Topic`: The topic on which to publish the 3D point (no orientation) in the Rviz environment when the left mouse button is clicked.
+    - Note: If you want this to match the output of the `Publish Point` tool, you can remap `/tool_cursor_point` to `/clicked_point`.  Alternatively, you can edit this in the `Panels > Tool Properties` menu.
 - `Patch Size`: The number of pixels on a side with which to create a patch used for estimated the surface normal
 - `Color`: The color of the cursor visualization
 

--- a/src/rviz_tool_cursor/rviz_tool_cursor.cpp
+++ b/src/rviz_tool_cursor/rviz_tool_cursor.cpp
@@ -107,7 +107,7 @@ ToolCursor::ToolCursor()
                                              "The topic on which to publish pose messages",
                                              getPropertyContainer(), SLOT(updateTopic()), this);
 
-  point_topic_property_ = new rviz::StringProperty("Point Topic", "/clicked_point",
+  point_topic_property_ = new rviz::StringProperty("Point Topic", "/tool_cursor_point",
                                              "The topic on which to publish point messages",
                                              getPropertyContainer(), SLOT(updateTopic()), this);
 


### PR DESCRIPTION
As described in #16 , this package contains tools that publish poses on a unique topic. As of f81dc0f, the rviz_tool_cursor tools also publish 'point' messages on the topic created by the 'publish point' tool. Because they are both rviz plugins / tools, they publish from the same node, making remapping one or the other infeasible. This limits the parallel usage of the publish point tool and the tools from this package.

This PR changes the default topic to avoid collision with the Publish Point tool, in addition to documenting how to change that topic is use as a Publish Point replacement is desired.